### PR TITLE
Add parameter ReplaceTypeDefinition

### DIFF
--- a/Indented.StubCommand/public/New-StubCommand.ps1
+++ b/Indented.StubCommand/public/New-StubCommand.ps1
@@ -48,12 +48,13 @@ function New-StubCommand {
         })]
         [scriptblock]$FunctionBody,
 
+        # Allow types on parameters to be replaced by another type.
         [System.Collections.Hashtable[]]$ReplaceTypeDefinition
     )
 
     begin {
         if ($pscmdlet.ParameterSetName -eq 'FromString') {
-            $null = $PSBoundParameters.Remove('CommandName')
+            $null = $psboundparameters.Remove('CommandName')
             Get-Command $CommandName | New-StubCommand @PSBoundParameters
         } else {
             $commonParameters = ([CommonParameters]).GetProperties().Name
@@ -123,7 +124,7 @@ function New-StubCommand {
 
                     if ($param = [ProxyCommand]::GetParamBlock($CommandInfo)) {
                         foreach ($line in $param -split '\r?\n') {
-                            if ($PSBoundParameters.ContainsKey('ReplaceTypeDefinition')) {
+                            if ($psboundparameters.ContainsKey('ReplaceTypeDefinition')) {
                                 foreach ($type in $ReplaceTypeDefinition)
                                 {
                                     if ($line -match ('\[{0}\]' -f $type.ReplaceType))
@@ -146,7 +147,7 @@ function New-StubCommand {
                     CommandInfo = $CommandInfo
                 }
 
-                if ($PSBoundParameters.ContainsKey('ReplaceTypeDefinition')) {
+                if ($psboundparameters.ContainsKey('ReplaceTypeDefinition')) {
                     $newStubDynamicParamArguments['ReplaceTypeDefinition'] = $ReplaceTypeDefinition
                 }
 

--- a/Indented.StubCommand/public/New-StubDynamicParam.ps1
+++ b/Indented.StubCommand/public/New-StubDynamicParam.ps1
@@ -29,6 +29,7 @@ function New-StubDynamicParam {
         [Parameter(Mandatory, ValueFromPipeline)]
         [CommandInfo]$CommandInfo,
 
+        # Allow types on parameters to be replaced by another type. Also removes any parameter attribute using the type.
         [System.Collections.Hashtable[]]$ReplaceTypeDefinition
     )
 
@@ -49,7 +50,7 @@ function New-StubDynamicParam {
                                 AppendLine()
 
                 foreach ($attribute in $dynamicParam.Attributes) {
-                    if ($PSBoundParameters.ContainsKey('ReplaceTypeDefinition')) {
+                    if ($psboundparameters.ContainsKey('ReplaceTypeDefinition')) {
                         $skipAttribute = $false
 
                         foreach ($type in $ReplaceTypeDefinition)
@@ -122,7 +123,7 @@ function New-StubDynamicParam {
 
                 $parameterType = $dynamicParam.ParameterType.ToString()
 
-                if ($PSBoundParameters.ContainsKey('ReplaceTypeDefinition')) {
+                if ($psboundparameters.ContainsKey('ReplaceTypeDefinition')) {
                     foreach ($type in $ReplaceTypeDefinition)
                     {
                         if ($parameterType -match $type.ReplaceType)

--- a/Indented.StubCommand/public/New-StubModule.ps1
+++ b/Indented.StubCommand/public/New-StubModule.ps1
@@ -13,6 +13,30 @@ function New-StubModule {
         New-StubModule -FromModule DnsClient
 
         Create stub of the DnsClient module.
+
+    .EXAMPLE
+        New-StubModule -FromModule ActiveDirectory -Path C:\Temp -ReplaceTypeDefinition @(
+            @{
+                ReplaceType = 'System\.Nullable`1\[Microsoft\.ActiveDirectory\.Management\.\w*\]'
+                WithType = 'System.Object'
+            },
+            @{
+                ReplaceType = 'Microsoft\.ActiveDirectory\.Management\.Commands\.\w*'
+                WithType = 'System.Object'
+            },
+            @{
+                ReplaceType = 'Microsoft\.ActiveDirectory\.Management\.\w*'
+                WithType = 'System.Object'
+            }
+        )
+
+        Creates a stub module of all the cmdlets and types in the module ActiveDirectory
+        replacing specific types with another type. ReplaceTypeDefinition takes an
+        array of hashtables. The hashtable must have two properties; the property
+        ReplaceType contain the type name that should be replaced with the type
+        name specified in the property WithType. The property ReplaceType supports
+        regular expression.
+
     .NOTES
         Change log:
             10/08/2019 - Johan Ljunggren - Added parameter ReplaceTypeDefinition
@@ -42,7 +66,7 @@ function New-StubModule {
         # By default, New-StubModule uses the Module parameter of Get-Command to locate commands to stub. ForceSourceFilter makes command discovery dependent on the Source property of commands returned by Get-Command.
         [Switch]$ForceSourceFilter,
 
-        # Optional types to replace with the specified type.
+        # Allow types on parameters to be replaced by another type.
         [System.Collections.Hashtable[]]$ReplaceTypeDefinition
     )
 

--- a/Indented.StubCommand/public/New-StubModule.ps1
+++ b/Indented.StubCommand/public/New-StubModule.ps1
@@ -15,6 +15,7 @@ function New-StubModule {
         Create stub of the DnsClient module.
     .NOTES
         Change log:
+            10/08/2019 - Johan Ljunggren - Added parameter ReplaceTypeDefinition
             05/04/2017 - Chris Dent - Created.
     #>
 
@@ -39,7 +40,10 @@ function New-StubModule {
         [ScriptBLock]$FunctionBody,
 
         # By default, New-StubModule uses the Module parameter of Get-Command to locate commands to stub. ForceSourceFilter makes command discovery dependent on the Source property of commands returned by Get-Command.
-        [Switch]$ForceSourceFilter
+        [Switch]$ForceSourceFilter,
+
+        # Optional types to replace with the specified type.
+        [System.Collections.Hashtable[]]$ReplaceTypeDefinition
     )
 
     try {
@@ -79,6 +83,11 @@ function New-StubModule {
             if ($psboundparameters.ContainsKey('FunctionBody')) {
                 $StubCommandSplat = @{FunctionBody = $FunctionBody}
             }
+
+            if ($psboundparameters.ContainsKey('ReplaceTypeDefinition')) {
+                $StubCommandSplat['ReplaceTypeDefinition'] = $ReplaceTypeDefinition
+            }
+
             $_.Group | New-StubCommand @StubCommandSplat
         } | ForEach-Object {
             if ($psboundparameters.ContainsKey('Path')) {

--- a/Indented.StubCommand/test/public/New-StubCommand.tests.ps1
+++ b/Indented.StubCommand/test/public/New-StubCommand.tests.ps1
@@ -185,31 +185,78 @@ InModuleScope Indented.StubCommand {
         }
 
         Context 'Type definitions' {
-            BeforeAll {
-                Mock New-StubType {
-                    return $Type
+            Context 'When using parameter IncludeTypeDefinition' {
+                BeforeAll {
+                    Mock New-StubType {
+                        return $Type
+                    }
+
+                    [String]$typeName = 'z' + ([Guid]::NewGuid() -replace '-')
+                    Add-Type -TypeDefinition "
+                        public class $typeName
+                        {
+                            public string Name;
+                        }
+                    "
+
+                    Invoke-Expression "
+                        function Test-Function {
+                            param (
+                                [$typeName]`$Parameter
+                            )
+                        }
+                    "
                 }
 
-                [String]$typeName = 'z' + ([Guid]::NewGuid() -replace '-')
-                Add-Type -TypeDefinition "
-                    public class $typeName
-                    {
-                        public string Name;
-                    }
-                "
-
-                Invoke-Expression "
-                    function Test-Function {
-                        param (
-                            [$typeName]`$Parameter
-                        )
-                    }
-                "
+                It 'Includes type names in generated stubs' {
+                    $stub = New-StubCommand (Get-Command Test-Function) -IncludeTypeDefinition
+                    $stub | Should -Match $typeName
+                }
             }
 
-            It 'Includes type names in generated stubs' {
-                $stub = New-StubCommand (Get-Command Test-Function) -IncludeTypeDefinition
-                $stub | Should -Match $typeName
+            Context 'When using parameter ReplaceTypeDefinition' {
+                BeforeAll {
+                    [String]$namespaceName = 'Microsoft.ActiveDirectory.Management'
+                    [String]$className = 'ADObject'
+                    [String]$typeName = '{0}.{1}' -f $namespaceName, $className
+
+                    if (-not ($typeName -as [Type])) {
+                        Add-Type -TypeDefinition "
+                            namespace $namespaceName
+                            {
+                                public class $className
+                                {
+                                    public string Name;
+                                }
+                            }
+                        "
+                    }
+
+                    Invoke-Expression  "
+                        function Test-Function {
+                            param (
+                                [$typeName]`$Parameter
+                            )
+                        }
+                    "
+                }
+
+                It 'Should return a stub containing the replaced types, and have called New-StubDynamicParam' {
+                    $mockCommand = Get-Command Test-Function
+                    $stub = New-StubCommand $mockCommand -ReplaceTypeDefinition @(
+                        @{
+                            ReplaceType = [System.Text.RegularExpressions.Regex]::Escape($typeName)
+                            WithType = 'System.Object'
+                        }
+                    )
+
+                    Assert-MockCalled -CommandName New-StubDynamicParam -ParameterFilter {
+                        $PSBoundParameters.ContainsKey('ReplaceTypeDefinition')
+                    }
+
+                    $stub | Should -Not -Match $typeName
+                    $stub | Should -Match 'System.Object'
+                }
             }
         }
 

--- a/Indented.StubCommand/test/public/New-StubCommand.tests.ps1
+++ b/Indented.StubCommand/test/public/New-StubCommand.tests.ps1
@@ -251,7 +251,7 @@ InModuleScope Indented.StubCommand {
                     )
 
                     Assert-MockCalled -CommandName New-StubDynamicParam -ParameterFilter {
-                        $PSBoundParameters.ContainsKey('ReplaceTypeDefinition')
+                        $psboundparameters.ContainsKey('ReplaceTypeDefinition')
                     }
 
                     $stub | Should -Not -Match $typeName

--- a/Indented.StubCommand/test/public/New-StubModule.tests.ps1
+++ b/Indented.StubCommand/test/public/New-StubModule.tests.ps1
@@ -73,6 +73,25 @@ InModuleScope Indented.StubCommand {
             }
         }
 
+        Context 'Replace type definition' {
+            BeforeEach {
+                New-StubModule -FromModule 'TestDrive:\TestModule.psm1' -ReplaceTypeDefinition @(
+                    @{
+                        ReplaceType = 'Microsoft.*'
+                        WithType = 'System.Object'
+                    }
+                )
+            }
+
+            It 'Calls New-StubCommand with the correct parameter' {
+                Assert-MockCalled Get-StubRequiredType -Scope It
+
+                Assert-MockCalled -CommandName New-StubCommand -ParameterFilter {
+                    $PSBoundParameters.ContainsKey('ReplaceTypeDefinition')
+                }
+            }
+        }
+
         Context 'Save to file' {
             Mock New-StubCommand {
                 'function Test-Function { }'

--- a/README.md
+++ b/README.md
@@ -186,7 +186,44 @@ namespace System.Net
 
 ## Module examples
 
-Examples of stub modules created using the commands in this module are available:
+The following generates stubs for all commands and types in the module
+*ActiveDirectory*.
+
+```powershell
+New-StubModule -FromModule ActiveDirectory -Path C:\Temp
+```
+
+The following generates stubs with a function body for all commands.
+
+```powershell
+$functionBody = {
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+New-StubModule -FromModule ActiveDirectory -Path C:\Temp -FunctionBody $functionBody
+```
+
+The following generates stubs and for all commands the types starting with
+`Microsoft.ActiveDirectory.Management` are replaced with `System.Object`.
+
+```powershell
+New-StubModule -FromModule ActiveDirectory -Path C:\Temp -ReplaceTypeDefinition @(
+    @{
+        ReplaceType = 'System\.Nullable`1\[Microsoft\.ActiveDirectory\.Management\.\w*\]'
+        WithType = 'System.Object'
+    },
+    @{
+        ReplaceType = 'Microsoft\.ActiveDirectory\.Management\.Commands\.\w*'
+        WithType = 'System.Object'
+    },
+    @{
+        ReplaceType = 'Microsoft\.ActiveDirectory\.Management\.\w*'
+        WithType = 'System.Object'
+    }
+)
+```
+
+Examples of already created stub modules using this module are available:
 
 <https://github.com/indented-automation/Indented.StubCommand/tree/master/examples>
 


### PR DESCRIPTION
This proposes to add a parameter `ReplaceTypeDefinition` which can be used to replace a type against another type when a stub command is created. This also skips adding any parameter attributes that matches any of the types being replaced.

This is needed to be able to create workable stubs to use with Pester for the DSC resource module ActiveDirectoryDsc (in PR https://github.com/PowerShell/ActiveDirectoryDsc/pull/483).

This is a description how this change is practically used (part of the above PR) https://github.com/johlju/ActiveDirectoryDsc/blob/add-stubs/Tests/Unit/Stubs/README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/indented-automation/indented.stubcommand/21)
<!-- Reviewable:end -->
